### PR TITLE
feat: UI/UX 개선 및 헤더 통일화

### DIFF
--- a/src/navigation/HomeStack.tsx
+++ b/src/navigation/HomeStack.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import { View, Text, TouchableOpacity } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import HomeScreen from "../screens/homepage/screens/HomeScreen";
 import AddressScreen from "../screens/homepage/screens/AddressScreen";
@@ -21,17 +23,46 @@ export default function HomeStack() {
       <Stack.Screen 
         name="Address" 
         component={AddressScreen}
-        options={{ 
-          title: "주소 설정",
+        options={({ navigation }) => ({
+          headerTitle: () => (
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+              <Ionicons name="location" size={24} color="#8A2BE2" />
+              <Text style={{ fontSize: 20, fontWeight: 'bold', color: '#8A2BE2' }}>주소 설정</Text>
+            </View>
+          ),
           headerTitleAlign: "center",
-        }}
+          headerStyle: {
+            backgroundColor: '#fff',
+          },
+          headerTintColor: '#8A2BE2',
+        })}
       />
       <Stack.Screen 
         name="ProductDetail" 
         component={ProductDetailScreen}
-        options={{ 
-          headerShown: false,
-        }}
+        options={({ navigation }) => ({
+          headerTitle: () => (
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+              <Ionicons name="document-text" size={24} color="#8A2BE2" />
+              <Text style={{ fontSize: 20, fontWeight: 'bold', color: '#8A2BE2' }}>상세페이지</Text>
+            </View>
+          ),
+          headerTitleAlign: "center",
+          headerStyle: {
+            backgroundColor: '#fff',
+          },
+          headerTintColor: '#8A2BE2',
+          headerRight: () => (
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 16 }}>
+              <TouchableOpacity onPress={() => {}}>
+                <Ionicons name="heart-outline" size={24} color="#666" />
+              </TouchableOpacity>
+              <TouchableOpacity onPress={() => {}}>
+                <Ionicons name="share-outline" size={24} color="#666" />
+              </TouchableOpacity>
+            </View>
+          ),
+        })}
       />
       <Stack.Screen 
         name="ProductAdd" 

--- a/src/screens/homepage/product/ProductDetailScreen.tsx
+++ b/src/screens/homepage/product/ProductDetailScreen.tsx
@@ -907,26 +907,6 @@ export default function ProductDetailScreen({ navigation }: Props) {
 
   return (
     <SafeAreaView style={styles.container}>
-      {/* 헤더 */}
-      <View style={styles.header}>
-        <TouchableOpacity onPress={() => navigation.goBack()} style={styles.backButton}>
-          <Ionicons name="chevron-back" size={24} color="#8A2BE2" />
-        </TouchableOpacity>
-        <Text style={styles.headerTitle}>상세페이지</Text>
-        <View style={styles.headerActions}>
-          <TouchableOpacity onPress={handleToggleLike} style={styles.headerButton}>
-            <Ionicons 
-              name={isLiked ? "heart" : "heart-outline"} 
-              size={24} 
-              color={isLiked ? "#8A2BE2" : "#666"} 
-            />
-          </TouchableOpacity>
-          <TouchableOpacity style={styles.headerButton}>
-            <Ionicons name="share-outline" size={24} color="#666" />
-          </TouchableOpacity>
-        </View>
-      </View>
-
       <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
         {/* 상품 이미지 */}
         <View style={styles.imageContainer}>
@@ -1221,7 +1201,8 @@ export default function ProductDetailScreen({ navigation }: Props) {
             <Text style={styles.noticeText}>
               • 모구 참여 후 거래가 성사되면 알림을 보내드립니다.{'\n'}
               • 만남 장소와 시간을 꼭 확인해주세요.{'\n'}
-              • 모구장 제외 인원으로 1/n 금액이 책정됩니다.
+              • 금액은 모구장 포함 1/n으로 책정됩니다.{'\n'}
+              • 인원 미충족 시 모구장이 나머지 수량과 금액을 부담합니다.
             </Text>
           </View>
         </View>
@@ -1573,39 +1554,6 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: "#f8f9fa",
   },
-  header: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    paddingHorizontal: 20,
-    paddingVertical: 15,
-    marginTop: 25,
-    backgroundColor: "#fff",
-    borderBottomWidth: 1,
-    borderBottomColor: "#f0f0f0",
-    position: "relative",
-  },
-  backButton: {
-    padding: 4,
-    zIndex: 1,
-  },
-  headerTitle: {
-    position: "absolute",
-    left: 0,
-    right: 0,
-    fontSize: 18,
-    fontWeight: "bold",
-    color: "#333",
-    textAlign: "center",
-  },
-  headerActions: {
-    flexDirection: "row",
-    zIndex: 1,
-  },
-  headerButton: {
-    marginLeft: 16,
-    padding: 4,
-  },
   content: {
     flex: 1,
   },
@@ -1884,9 +1832,11 @@ const styles = StyleSheet.create({
   modalContent: {
     backgroundColor: "#fff",
     borderRadius: 20,
-    padding: 40,
+    padding: 30,
     alignItems: "center",
     minWidth: 280,
+    maxWidth: "75%",
+    marginHorizontal: 20,
   },
   compactModalContent: {
     backgroundColor: "#fff",
@@ -1952,6 +1902,7 @@ const styles = StyleSheet.create({
     justifyContent: "space-between",
     width: "100%",
     gap: 12,
+    marginTop: 10,
   },
   cancelModalButton: {
     backgroundColor: "#f0f0f0",

--- a/src/screens/homepage/screens/AddressScreen.tsx
+++ b/src/screens/homepage/screens/AddressScreen.tsx
@@ -246,15 +246,6 @@ export default function AddressScreen({ navigation }: Props) {
 
   return (
     <View style={styles.container}>
-      {/* 타이틀 섹션 */}
-      <View style={styles.titleSection}>
-        <View style={styles.titleRow}>
-          <Ionicons name="location" size={28} color="#8A2BE2" />
-          <Text style={styles.title}>주소 설정</Text>
-        </View>
-        <Text style={styles.subtitle}>배송받을 주소를 선택하거나 추가해주세요</Text>
-      </View>
-
       {/* 검색창 */}
       <View style={styles.searchBox}>
         <Ionicons name="search-outline" size={20} color="#8A2BE2" />
@@ -303,7 +294,7 @@ export default function AddressScreen({ navigation }: Props) {
             : `search-${(item as NormalizedAddress).address_name}-${index}`
         }
         renderItem={renderItem}
-        style={{ marginTop: 15 }}
+        contentContainerStyle={styles.listContainer}
         ListEmptyComponent={
           query.trim() ? (
             <View style={styles.emptyContainer}>
@@ -321,27 +312,6 @@ const styles = StyleSheet.create({
   container: { 
     flex: 1, 
     backgroundColor: "#f8f9fa", 
-    padding: 20 
-  },
-  titleSection: {
-    marginBottom: 24,
-    paddingTop: 20,
-  },
-  titleRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    marginBottom: 8,
-  },
-  title: {
-    fontSize: 26,
-    fontWeight: "bold",
-    color: "#333",
-    marginLeft: 10,
-  },
-  subtitle: {
-    fontSize: 14,
-    color: "#666",
-    marginLeft: 38,
   },
   searchBox: {
     flexDirection: "row",
@@ -352,6 +322,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingVertical: 12,
     backgroundColor: "#fff",
+    marginHorizontal: 20,
+    marginTop: 20,
     shadowColor: "#8A2BE2",
     shadowOffset: {
       width: 0,
@@ -369,6 +341,7 @@ const styles = StyleSheet.create({
   },
   locationBtn: {
     marginTop: 12,
+    marginHorizontal: 20,
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
@@ -389,6 +362,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
     marginTop: 24,
     marginBottom: 8,
+    marginHorizontal: 20,
   },
   dividerLine: {
     flex: 1,
@@ -400,6 +374,11 @@ const styles = StyleSheet.create({
     fontSize: 13,
     color: "#999",
     fontWeight: "600",
+  },
+  listContainer: {
+    paddingHorizontal: 20,
+    paddingTop: 15,
+    paddingBottom: 20,
   },
   addressItem: {
     flexDirection: "row",

--- a/src/screens/homepage/screens/HomeScreen.tsx
+++ b/src/screens/homepage/screens/HomeScreen.tsx
@@ -258,13 +258,6 @@ export default function HomeScreen() {
       >
         {/* 이미지 컨테이너 */}
         <View style={styles.imageContainer}>
-          {/* AI 추천 배지 */}
-          {selectedFilter === "AI 추천" && item.aiScore >= 90 && (
-            <View style={styles.aiBadge}>
-              <Ionicons name="sparkles" size={9} color="#FFD700" />
-            </View>
-          )}
-
           <Image source={item.image} style={styles.productImage} />
           
           {/* 하트 버튼 */}
@@ -602,20 +595,6 @@ const styles = StyleSheet.create({
   imageContainer: {
     position: 'relative',
     width: '100%',
-  },
-  aiBadge: {
-    position: "absolute",
-    top: 8,
-    left: 8,
-    width: 24,
-    height: 24,
-    borderRadius: 12,
-    backgroundColor: "rgba(255, 249, 230, 0.95)",
-    justifyContent: 'center',
-    alignItems: 'center',
-    zIndex: 2,
-    borderWidth: 1,
-    borderColor: "#FFD700",
   },
   productImage: { 
     width: "100%",

--- a/src/screens/homepage/screens/NotificationScreen.tsx
+++ b/src/screens/homepage/screens/NotificationScreen.tsx
@@ -204,15 +204,19 @@ const NotificationScreen = () => {
       {/* 헤더 */}
       <View style={styles.header}>
         <TouchableOpacity onPress={() => navigation.goBack()} style={styles.backButton}>
-          <Ionicons name="chevron-back" size={24} color="black" />
+          <Ionicons name="chevron-back" size={24} color="#8A2BE2" />
         </TouchableOpacity>
-        <Text style={styles.headerTitle}>알림</Text>
-        {unreadCount > 0 && (
+        <View style={styles.headerTitleContainer}>
+          <Ionicons name="notifications" size={24} color="#8A2BE2" />
+          <Text style={styles.headerTitle}>알림</Text>
+        </View>
+        {unreadCount > 0 ? (
           <TouchableOpacity onPress={handleMarkAllAsRead}>
             <Text style={styles.markAllReadText}>모두 읽음</Text>
           </TouchableOpacity>
+        ) : (
+          <View style={{ width: 60 }} />
         )}
-        {unreadCount === 0 && <View style={{ width: 60 }} />}
       </View>
 
       {/* 탭 */}
@@ -264,22 +268,36 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
   },
   header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: 15,
-    paddingTop: 50,
-    paddingBottom: 15,
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingHorizontal: 20,
+    paddingVertical: 15,
+    marginTop: 25,
+    backgroundColor: "#fff",
     borderBottomWidth: 1,
-    borderBottomColor: '#f0f0f0',
+    borderBottomColor: "#f0f0f0",
+    shadowColor: "#000",
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    shadowOpacity: 0.05,
+    shadowRadius: 4,
+    elevation: 2,
   },
   backButton: {
-    padding: 5,
+    padding: 4,
+  },
+  headerTitleContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
   },
   headerTitle: {
-    fontSize: 18,
-    fontWeight: 'bold',
-    color: '#333',
+    fontSize: 20,
+    fontWeight: "bold",
+    color: "#8A2BE2",
   },
   markAllReadText: {
     fontSize: 14,


### PR DESCRIPTION
- 헤더 디자인 통일화
* 주소 설정, 알림, 상세 페이지 헤더를 모구하기 페이지와 동일한 스타일로 통일
* 네이티브 헤더에 아이콘 추가 (주소 설정: location, 알림: notifications, 상세: document-text)
* 폰트 크기 20px, 색상 #8A2BE2로 통일
* 상세 페이지 헤더에 하트/공유 버튼 추가

- 모달 디자인 개선
* 모구 취소 모달을 다른 모달들과 동일한 템플릿으로 변경
* 모달 크기 조정 (maxWidth 75%로 축소)
* 하단 슬라이드 애니메이션 적용

- 모구 안내 텍스트 개선
* 모구장의 역할과 책임을 명확히 명시
* "금액은 모구장 포함 1/n으로 책정" 안내 추가
* "인원 미충족 시 모구장이 나머지 수량과 금액 부담" 안내 추가

- UI 정리
* AI 추천 상품 이미지의 불필요한 아이콘 제거
* 주소 설정 페이지 중복 헤더 제거
* 네이티브 헤더 사용으로 일관성 확보